### PR TITLE
Set SQLITE_TMPDIR to / for scratch containers

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -3,5 +3,6 @@ COPY --from=alpine:latest /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY build/oxeye-backend /oxeye-backend
 ENV DATABASE_PATH=/oxeye.db
 ENV PORT=3000
+ENV SQLITE_TMPDIR=/
 EXPOSE 3000
 ENTRYPOINT ["/oxeye-backend"]

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -3,5 +3,6 @@ COPY --from=alpine:latest /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY build/oxeye-backend /oxeye-backend
 ENV DATABASE_PATH=/oxeye.db
 ENV PORT=3000
+ENV SQLITE_TMPDIR=/
 EXPOSE 3000
 ENTRYPOINT ["/oxeye-backend"]


### PR DESCRIPTION
- Add SQLITE_TMPDIR environment variable to both amd64 and arm64 Dockerfiles
- Points to root directory which is guaranteed to exist in scratch containers
- Fixes SQLite temporary file directory issues in minimal containers