### PR TITLE
Add design document for Minecraft skin head images

### DIFF
--- a/MINECRAFT_SKIN_HEAD_IMAGES_DESIGN.md
+++ b/MINECRAFT_SKIN_HEAD_IMAGES_DESIGN.md
@@ -811,7 +811,7 @@ The implementation will be considered successful if:
 
 ## Future Enhancements (Out of Scope)
 
-- 3D isometric head renders (using nmsr-rs)
+- 3D isometric head renders (would require external service like nmsr-rs)
 - Full body renders
 - Cape rendering
 - Multiple render sizes (32x32, 128x128)


### PR DESCRIPTION
This design document covers the architecture for displaying player
head images in Discord embeds while minimizing rendering operations
and network transfers.

Key decisions:
- Hash GameProfile texture value for change detection (zero network cost)
- Store skins and rendered heads as SQLite BLOBs (simple, fast)
- Two-step protocol: send hash first, backend responds 202 if needs skin
- Fire-and-forget async rendering with Steve head fallback
- Serve images by texture hash for immutable CDN-friendly URLs
- Deduplicate skins across players (one render per unique skin)

Performance characteristics:
- 67x bandwidth reduction for repeat joins
- 10x fewer rendering operations (render once per unique skin)
- <5ms latency for serving heads from SQLite